### PR TITLE
Create PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ### :memo: Summary of changes
 Please summarise changes made in this pull request
 
-### 🤔 Considerations 
-This repository is public. Please ensure:
-- [ ] Template does not include any sensitive information. 
+### 📋 PR checklist 
+- [ ] Do not include any sensitive information (templates are public)
+- [ ] Increase the template version if there have been significant changes to the template functionality (i.e adding a new step to a procedure template).   

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+### :memo: Summary of changes
+Please summarise changes made in this pull request
+
+### 🤔 Considerations 
+This repository is public. Please ensure:
+- [ ] Template does not include any sensitive information. 


### PR DESCRIPTION
@rachellimop @isaacojq11 this is a template for pull requests made on this repo. When you make a pull request the PR body in Github will automatically be populated with this content. Because this repo is public it will make it nicer to see history of what was changed if we have more detailed summaries in the pull requests. Is there anything you would like to add to this?

- Added as a hidden file in `.github/`
- Pretty simple and short - @btabram anything else you wanted to include?